### PR TITLE
NTI-3718: Make sure the record is defined before calling update

### DIFF
--- a/src/main/js/legacy/app/course/overview/components/editing/content/video/Editor.js
+++ b/src/main/js/legacy/app/course/overview/components/editing/content/video/Editor.js
@@ -176,7 +176,10 @@ module.exports = exports = Ext.define('NextThought.app.course.overview.component
 
 	onVideoDelete (ntiid) {
 		this.videoSelectionCmp.deleteSelectionItem(ntiid);
-		if (this.record) {
+		if (this.record instanceof Video) {
+			this.parentRecord.updateFromServer();
+			delete this.record;
+		} else if (this.record instanceof VideoRoll) {
 			this.record.updateFromServer();
 		}
 	},


### PR DESCRIPTION
This happens when the video is being added a single video and not in a video roll.