### PR TITLE
NTI-4966: Fix routing issue

### DIFF
--- a/src/main/js/legacy/app/course/admin/Index.js
+++ b/src/main/js/legacy/app/course/admin/Index.js
@@ -55,7 +55,7 @@ module.exports = exports = Ext.define('NextThought.app.course.admin.Index', {
 			this.siteAdminTools.show();
 			this.siteAdminTools.setBaseRoute(baseroute);	
 		} else if (this.siteAdminRoster && ROSTER_ACTIVE.test(route.path)) {
-			maybeHide(this.siteAdminTools.hide());
+			maybeHide(this.siteAdminTools);
 
 			this.siteAdminRoster.show();
 		} else if (!this.siteAdminTools && !ROSTER_ACTIVE.test(route.path)) {


### PR DESCRIPTION
Forgot to remove the .hide from siteAdminTools. It's checked if it's defined inside the maybeHide func and called there. 