### PR TITLE
NTI-8936: Real Name Optional

### DIFF
--- a/src/main/js/nti-web-site-admin/components/users/list/table/InvitationsStore.js
+++ b/src/main/js/nti-web-site-admin/components/users/list/table/InvitationsStore.js
@@ -83,7 +83,7 @@ class UserInvitationsStore extends Stores.BoundStore {
 				payload.append('source', file);
 			} else {
 				payload = {
-					invitations: emails.map(x => { return { 'receiver': x, 'receiver_name': x }; }),
+					invitations: emails.map(x => { return { 'receiver': x }; }),
 					message,
 					MimeType: isAdmin ? Models.invitations.SiteAdminInvitation.MimeType : Models.invitations.SiteInvitation.MimeType
 				};


### PR DESCRIPTION
Server made this optional and we shouldn't pass the email as the real name now because this will be rejected by the preflight prefill on thee login app.