### PR TITLE
encode each uri component properly. Fixes #tag not being sent to server

### DIFF
--- a/src/main/js/legacy/app/search/Actions.js
+++ b/src/main/js/legacy/app/search/Actions.js
@@ -66,7 +66,7 @@ module.exports = exports = Ext.define('NextThought.app.search.Actions', {
 
 		location = Globals.CONTENT_ROOT;
 
-		url = cachedHref || [rootUrl, location, '/', term].join('');
+		url = cachedHref || [rootUrl, encodeURIComponent(location), '/', encodeURIComponent(term)].join('');
 
 		accepts = (accepts || []).map(function (mime) {
 			return 'application/vnd.nextthought.' + mime;


### PR DESCRIPTION
NTI-9259 make sure our search context and term components are properly encoded before building the url.