### PR TITLE
NTI-9492 - include 'auto_publish' param in new unit payload

### DIFF
--- a/src/main/js/legacy/app/course/overview/components/editing/outline/outlinenode/AddNode.js
+++ b/src/main/js/legacy/app/course/overview/components/editing/outline/outlinenode/AddNode.js
@@ -118,7 +118,7 @@ module.exports = exports = Ext.define('NextThought.app.course.overview.component
 	 * That behavior may eventually change, in which case this will need to be adjusted too.
 	 *
 	 * @param  {Event} e  Browser click event
-	 * @return {Promise}   returns a promise that fulfills after the record is published.
+	 * @returns {Promise}   returns a promise that fulfills after the record is published.
 	 */
 	onSave: function (e) {
 		var values = this.editor.getValue(),
@@ -153,12 +153,8 @@ module.exports = exports = Ext.define('NextThought.app.course.overview.component
 
 		this.isSaving = true;
 
-		return parent.appendContent(values)
+		return parent.appendContent({...values, 'auto_publish': !!this.autoPublish})
 			.then((rec) => {
-				if (this.autoPublish) {
-					this.EditingActions.publish(rec);
-				}
-
 				this.editor.el.unmask();
 				this.addLessonEl.show();
 				this.hideEditor();


### PR DESCRIPTION
[NTI-9492](https://nextthought.atlassian.net/browse/NTI-9492) - Includes an `auto_publish` parameter in the new unit payload instead of sending a separate publish request after unit creation.
