### PR TITLE
NTI-10700 - clean up sortable library flags

### DIFF
--- a/src/main/js/legacy/app/library/LibrarySearchable.js
+++ b/src/main/js/legacy/app/library/LibrarySearchable.js
@@ -1,11 +1,9 @@
 const Ext = require('@nti/extjs');
-const { View: LibrarySearchableView } = require('@nti/web-library');
-const { ViewSortable: LibrarySortableView } = require('@nti/web-library');
+const { View: LibraryView } = require('@nti/web-library');
 const { Theme } = require('@nti/web-commons');
 const NavigationActions = require('internal/legacy/app/navigation/Actions');
 const BundleActions = require('internal/legacy/app/bundle/Actions');
 const CourseActions = require('internal/legacy/app/course/Actions');
-const { isFlag } = require('@nti/web-client');
 
 const GlobalTheme = Theme.getGlobalTheme();
 
@@ -43,10 +41,6 @@ module.exports = exports = Ext.define('NextThought.app.library.Index', {
 	},
 
 	showLibrary(route) {
-		const LibraryComponent = isFlag('library-sorting')
-			? LibrarySortableView
-			: LibrarySearchableView;
-
 		const LibraryTheme = GlobalTheme.scope('library');
 		const { background } = LibraryTheme;
 		const dark = background == null ? true : background === 'dark';
@@ -72,7 +66,7 @@ module.exports = exports = Ext.define('NextThought.app.library.Index', {
 		} else {
 			this.library = this.add({
 				xtype: 'react',
-				component: LibraryComponent,
+				component: LibraryView,
 				baseroute: baseroute,
 				setTitle: title => {
 					this.setTitle(title);


### PR DESCRIPTION
Removes non-sortable library code paths and corresponding feature flags checks. Depends on PRs in [web/course] and  [web/library].